### PR TITLE
Fixed a bad error on some nil returns

### DIFF
--- a/lib/meta-spotify.rb
+++ b/lib/meta-spotify.rb
@@ -31,13 +31,13 @@ module MetaSpotify
       end
       return { (item_name+'s').to_sym => items,
                :query => {
-                 :start_page => result["opensearch:Query"]["startPage"].to_i,
-                 :role => result["opensearch:Query"]["role"],
-                 :search_terms => result["opensearch:Query"]["searchTerms"]
+                 :start_page => result["opensearch:Query"].try(:[], "startPage").nil? ? result["opensearch:Query"] : result["opensearch:Query"]["startPage"],
+                 :role => result["opensearch:Query"].try(:[], "role").nil? ? result["opensearch:Query"] : result["opensearch:Query"]["role"],
+                 :search_terms => result["opensearch:Query"].try(:[], "searchTerms").nil? ? result["opensearch:Query"] : result["opensearch:Query"]["searchTerms"]
                },
-               :items_per_page => result["opensearch:itemsPerPage"].to_i,
-               :start_index => result["opensearch:startIndex"].to_i,
-               :total_results => result["opensearch:totalResults"].to_i
+               :items_per_page => result["opensearch:itemsPerPage"],
+               :start_index => result["opensearch:startIndex"],
+               :total_results => result["opensearch:totalResults"]
               }
     end
     


### PR DESCRIPTION
Was getting an error in the Track search method as follows. Simply wrote a ternary to catch any nil values from array [].

1.9.2p290 :001 > search = MetaSpotify::Artist.search('foo')
NoMethodError: You have a nil object when you didn't expect it!
You might have expected an instance of Array.
The error occurred while evaluating nil.[]
    from /Users/amanelis/.rvm/gems/ruby-1.9.2-p290@console/gems/meta-spotify-0.1.5/lib/meta-spotify.rb:45:in `search'
    from (irb):1
    from /Users/amanelis/.rvm/gems/ruby-1.9.2-p290@console/gems/railties-3.1.0/lib/rails/commands/console.rb:45:in`start'
    from /Users/amanelis/.rvm/gems/ruby-1.9.2-p290@console/gems/railties-3.1.0/lib/rails/commands/console.rb:8:in `start'
    from /Users/amanelis/.rvm/gems/ruby-1.9.2-p290@console/gems/railties-3.1.0/lib/rails/commands.rb:40:in`<top (required)>'
    from script/rails:6:in `require'
    from script/rails:6:in`<main>'
1.9.2p290 :002 > exit
